### PR TITLE
Fix iOS 16 IPv6 bug

### DIFF
--- a/Sources/WireGuardKit/IPAddress+AddrInfo.swift
+++ b/Sources/WireGuardKit/IPAddress+AddrInfo.swift
@@ -8,7 +8,7 @@ extension IPv4Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: MemoryLayout<sockaddr_in>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin_addr, count: MemoryLayout<in_addr>.size)
         }
 
@@ -20,7 +20,7 @@ extension IPv6Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET6 else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: MemoryLayout<sockaddr_in6>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin6_addr, count: MemoryLayout<in6_addr>.size)
         }
 


### PR DESCRIPTION
Making same fix made [by Mullvad](https://github.com/WireGuard/wireguard-apple/commit/fe90def15c601722a5fb6688485ab277a15a37df).

From testing, this seems to fix our problem.